### PR TITLE
Important fix to EPE calc

### DIFF
--- a/multiscaleloss.py
+++ b/multiscaleloss.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 
 def EPE(input_flow, target_flow, sparse=False, mean=True):
-    EPE_map = torch.norm(target_flow-input_flow,2,1)
+    EPE_map = torch.norm(target_flow-input_flow,2,2)
     batch_size = EPE_map.size(0)
     if sparse:
         # invalid flow is defined with both flow coordinates to be exactly 0


### PR DESCRIPTION
This will be the first of several pull request extending the excellent code base. Comparing the EPE calc with the official version provided by the Middleburry data set, it came to my attention that torch.norm(...,2,2) creates the required flow_map, torch.norm(...,2,1) does not. Hope we can get this out quickly :)