### PR TITLE
ensure reproduciblity & consistent restart on Tensorboard side

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,12 @@ group.add_argument('-s', '--split-file', default=None, type=str,
 group.add_argument('--split-value', default=0.8, type=float,
                    help='test-val split proportion between 0 (only test) and 1 (only train), '
                         'will be overwritten if a split file is set')
+parser.add_argument(
+    "--split-seed",
+    type=int,
+    default=None,
+    help="Seed the train-val split to enforce reproducibility (consistent restart too)",
+)
 parser.add_argument('--arch', '-a', metavar='ARCH', default='flownets',
                     choices=model_names,
                     help='model architecture, overwritten if pretrained is specified: ' +
@@ -79,11 +85,7 @@ parser.add_argument('--div-flow', default=20,
                     help='value by which flow will be divided. Original value is 20 but 1 with batchNorm gives good results')
 parser.add_argument('--milestones', default=[100,150,200], metavar='N', nargs='*', help='epochs at which learning rate is divided by 2')
 
-parser.add_argument(
-    "--seed-split",
-    default=None,
-    help="Seed the train-val split to enforce reproducibility (consistent restart too)",
-)
+
 
 best_EPE = -1
 n_iter = int(start_epoch)
@@ -108,8 +110,8 @@ def main():
     if not os.path.exists(save_path):
         os.makedirs(save_path)
 
-    if args.seed_split:
-        np.random.seed(int(args.seed_split))
+    if args.seed_split is not None:
+        np.random.seed(args.seed_split)
 
     train_writer = SummaryWriter(os.path.join(save_path,'train'))
     test_writer = SummaryWriter(os.path.join(save_path,'test'))


### PR DESCRIPTION
Hi,
`parser.add_argument(
    "--seed-split",
    default=None,
    help="Seed the train-val split to enforce reproducibility (consistent restart too)"
)`

I added the seed argument to fix randomness when splitting the FlyingChairs dataset for example, it ensures to obtain the exact same results when running multiple times the experiment.

It will also give us the same validation images which appears in Tensorboard.
Without this seed, when we start from a checkpoint we obtain in the TensorBoard (Image section) FlowNet predictions of images which are different from the first run of the model ( that gave us the checkpoint), thus we can't see the real progress on a single image.

In this case if reproducibility this line : `if epoch == args.start_epoch:` is useless because we are will be working on the same image, so no need to add the same groundtruth and input images" but if you don't want to have this reproducibility, this  line should stay because we can compare the new OF prediction with Groudtruth and original new images.

This line `n_iter = int(start_epoch)` is to ensure that curves  printed in TensorBoard start from the epoch where we stopped training in the first moment (in the checkpointing case too) .

That's it :+1: 